### PR TITLE
Add viewport meta tag for responsive design

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -46,6 +46,13 @@ module.exports = {
         [
             "meta",
             {
+                name: "viewport",
+                content: "width=device-width,initial-scale=1.0"
+            }
+        ],
+        [
+            "meta",
+            {
                 name: "apple-mobile-web-app-title",
                 content: "Project V"
             }


### PR DESCRIPTION
Viewport meta tag is necessary for responsive design on new Firefox for Android (Fenix).

vuejs/vuepress#2369