### PR TITLE
docs: change Azure Pipeline to GitHub Actions

### DIFF
--- a/docs/developer/intro/guide.md
+++ b/docs/developer/intro/guide.md
@@ -12,7 +12,7 @@ Git
 
 ### 发布（Release）
 
-尽量使用自动化工具发布，比如 v2ray-core 使用 Azure Pipelines 作为自动编译和发布工具。
+尽量使用自动化工具发布，比如 v2ray-core 使用 GitHub Actions 作为自动编译和发布工具。
 
 ### 引用其它项目
 


### PR DESCRIPTION
The main v2fly/v2ray-core repo has been using the GitHub Actions for a while now.
I found that the CI/CD tool which is written in the docs for developers is still not updated.