### PR TITLE
Set larger `poolSize` that match CIDR

### DIFF
--- a/docs/config/fakedns.md
+++ b/docs/config/fakedns.md
@@ -7,7 +7,7 @@
 ```json
 {
     "ipPool": "240.0.0.0/8",
-    "poolSize": 65535
+    "poolSize": 16777214
 }
 ```
 


### PR DESCRIPTION
强迫症作祟吧，看到 /8 这么大的一个子网居然只给六万多 IP 的池子感觉非常不合理。
考虑到参考文档的人不一定有计算机网络的基础，同时也为了避免极端使用场景下 IP 池耗尽的问题，我想这里建议一个大一点的值会比较好。
当然我本人没有多少使用 fakedns 的经验，也许 65535 是更合理的值，欢迎讨论。