### PR TITLE
fix: rename tag perproxy -> streamsettingsobject

### DIFF
--- a/docs/config/inbounds.md
+++ b/docs/config/inbounds.md
@@ -56,9 +56,9 @@ v4.32.0+，支持填写 Unix domain socket，格式为绝对路径，形如 `"/d
 
 具体的配置内容，视协议不同而不同。详见每个协议中的 `InboundConfigurationObject`。
 
-> `streamSettings`: [StreamSettingsObject](transport.md#perproxy)。
+> `streamSettings`: [StreamSettingsObject](transport.md#streamsettingsobject)。
 
-[底层传输配置](transport.md#perproxy)
+[底层传输配置](transport.md#streamsettingsobject)
 
 > `tag`: string
 

--- a/docs/config/outbounds.md
+++ b/docs/config/outbounds.md
@@ -68,7 +68,6 @@
 
 如果不启用此选项, 在转发时传输层协议将失效，只能使用默认的 TCP 传输协议。
 
-
 ## MuxObject
 
 Mux 功能是在一条 TCP 连接上分发多个 TCP 连接的数据。实现细节详见 [Mux.Cool](../developer/protocols/muxcool.md)。Mux 是为了减少 TCP 的握手延迟而设计，而非提高连接的吞吐量。使用 Mux 看视频、下载或者测速通常都有反效果。Mux 只需要在客户端启用，服务器端自动适配。

--- a/docs/config/outbounds.md
+++ b/docs/config/outbounds.md
@@ -37,9 +37,9 @@
 
 此出站连接的标识，用于在其它的配置中定位此连接。当其值不为空时，必须在所有 tag 中唯一。
 
-> `streamSettings`: [StreamSettingsObject](transport.md#perproxy)
+> `streamSettings`: [StreamSettingsObject](transport.md#streamsettingsobject)
 
-[底层传输配置](transport.md#perproxy)
+[底层传输配置](transport.md#streamsettingsobject)
 
 > `proxySettings`: [ProxySettingsObject](#proxysettingsobject)
 

--- a/docs/en_US/config/outbounds.md
+++ b/docs/en_US/config/outbounds.md
@@ -36,9 +36,9 @@ The specific configuration content varies depending on the protocol. See `Outbou
 
 The identifier of this outbound connection, used to locate this connection in other configurations. When its value is not empty, it must be unique among all tags.
 
-> `streamSettings`: [StreamSettingsObject](transport.md#perproxy)
+> `streamSettings`: [StreamSettingsObject](transport.md#streamsettingsobject)
 
-[Low-level transmission configuration](transport.md#perproxy)
+[Low-level transmission configuration](transport.md#streamsettingsobject)
 
 > `proxySettings`: [ProxySettingsObject](#proxysettingsobject)
 


### PR DESCRIPTION
I don't know where is `#perproxy`, may be it should be `#streamsettingsobject`.