### PR TITLE
Fix FakeDNS configuration

### DIFF
--- a/docs/config/fakedns.md
+++ b/docs/config/fakedns.md
@@ -2,28 +2,12 @@
 
 ## FakeDnsObject
 
-`FakeDnsObject` 可以配置单个或多个地址池，格式如下所示。(4.38.1+)
+`FakeDnsObject` 对应配置文件 `fakedns` 项的一个子元素。(4.38.1+)
 
 ```json
 {
-    "fakedns": {
-        "ipPool": "198.18.0.0/15",
-        "poolSize": 65535
-    }
-}
-```
-```json
-{
-    "fakedns": [
-        {
-            "ipPool": "198.18.0.0/15",
-            "poolSize": 65535
-        },
-        {
-            "ipPool": "fc00::/18",
-            "poolSize": 65535
-        }
-    ]
+    "ipPool": "198.18.0.0/15",
+    "poolSize": 65535
 }
 ```
 

--- a/docs/config/fakedns.md
+++ b/docs/config/fakedns.md
@@ -14,18 +14,16 @@
 ```
 ```json
 {
-    "fakedns": {
-        "pools": [
-            {
-                "ipPool": "198.18.0.0/15",
-                "poolSize": 65535
-            },
-            {
-                "ipPool": "fc00::/18",
-                "poolSize": 65535
-            }
-        ]
-    }
+    "fakedns": [
+        {
+            "ipPool": "198.18.0.0/15",
+            "poolSize": 65535
+        },
+        {
+            "ipPool": "fc00::/18",
+            "poolSize": 65535
+        }
+    ]
 }
 ```
 

--- a/docs/config/fakedns.md
+++ b/docs/config/fakedns.md
@@ -13,18 +13,18 @@
 
 > `ipPool`: string: CIDR
 
-FakeDNS 分配 IP 的地址空间。由 FakeDNS 分配的地址会符合这个 CIDR 表达式。IPv4 网络下，默认值为 `198.18.0.0/15`；IPv6 网络下，默认值为 `fc00::/18`。
+FakeDNS 分配 IP 的地址空间。由 FakeDNS 分配的地址会符合这个 CIDR 表达式。
 
 > `poolSize`: number
 
-FakeDNS 所记忆的「IP - 域名映射」数量。当域名数量超过此数值时，会依据 [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) 规则淘汰老旧域名。默认为 `65535`。
+FakeDNS 所记忆的「IP - 域名映射」数量。当域名数量超过此数值时，会依据 [LRU](https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)) 规则淘汰老旧域名。
 
 :::warning
 poolSize 必须小于或等于 ipPool 的地址总数，否则 core 将无法启动。
 :::
 
 :::tip
-自 v4.38.1 起，若配置文件中的 `dns` 项显式设置了 `fakedns`，而配置文件中没有显式设置 `fakedns` 项，V2Ray 会根据 DNS 模块中 `queryStrategy` 项的值来初始化 `fakedns` 项的配置，即 FakeDNS 是否支持对不同类型 DNS 查询（A 记录和 AAAA 记录）返回相应的 IPv4 或 IPv6 类型的 IP 地址。
+自 v4.38.1 起，若配置文件中的 `dns` 项显式设置了 `fakedns`，而配置文件中没有显式设置 `fakedns` 项，V2Ray 会根据 DNS 模块中 `queryStrategy` 项的值来初始化 `fakedns` 项的配置，即 FakeDNS 是否支持对不同类型 DNS 查询（A 记录和 AAAA 记录）返回相应的 IPv4 或 IPv6 类型的 IP 地址。`queryStrategy` 为 `UseIPv4` 时，默认的 `ipPool` 为 `198.18.0.0/15`，`poolSize` 为 `65535`；`queryStrategy` 为 `UseIPv6` 时，默认的 `ipPool` 为 `fc00::/18`，`poolSize` 为 `65535`；`queryStrategy` 为 `UseIP` 时，默认用于 IPv4 的 `ipPool` 为 `198.18.0.0/15`，`poolSize` 为 `32768`，用于 IPv6 的 `ipPool` 为 `fc00::/18`，`poolSize` 为 `32768`。
 :::
 
 ## 运行机制及配置方式

--- a/docs/config/overview.md
+++ b/docs/config/overview.md
@@ -64,7 +64,7 @@ V2Ray 的配置文件形式如下，客户端和服务器通用一种形式，�
 
 反向代理。
 
-> `fakedns`: [FakeDnsObject](fakedns.md)
+> `fakedns`: \[ [FakeDnsObject](fakedns.md) \]
 
 虚拟 DNS 服务器。
 


### PR DESCRIPTION
https://github.com/v2fly/v2ray-core/commit/a21e4a7deb2d60b40ea4ebcedf6e22a56dcb4d04
`"fakedns": {}` should be considered deprecated (for backward compatibility only).
`pools: []` does not work since that commit.