### PR TITLE
fix: Correct Readme CC License link from BY to BY-SA

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ footer: Licensed under CC-BY-SA 4.0 | Copyleft 2015-Present V2Fly Community
 ## 授权
 
 - Core 使用 MIT 协议
-- 网站（[v2fly.org](https://www.v2fly.org/)）以 [CC BY SA 4.0 国际许可协议](https://creativecommons.org/licenses/by/4.0/deed.zh) 授权。
+- 网站（[v2fly.org](https://www.v2fly.org/)）以 [CC BY SA 4.0 国际许可协议](https://creativecommons.org/licenses/by-sa/4.0/deed.zh) 授权。
     * 包括网站中所有可见的文字内容和图片。
     * 包括 Project V 图标文件。
     * 包括生成网站所使用到的源代码，即 [v2fly/v2fly-github-io](https://github.com/v2fly/v2fly-github-io)。

--- a/docs/en_US/README.md
+++ b/docs/en_US/README.md
@@ -39,7 +39,7 @@ Welcome to contribute to the project! Even if you don't know how to write code, 
 ## Authorization
 
 - Core uses MIT License
-- The website ([v2fly.org](https://www.v2fly.org/)) is authorized under the [CC BY SA 4.0 International License Agreement](https://creativecommons.org/licenses/by/4.0/deed.zh) .
+- The website ([v2fly.org](https://www.v2fly.org/)) is authorized under the [CC BY SA 4.0 International License Agreement](https://creativecommons.org/licenses/by-sa/4.0/deed.zh) .
     * Including all visible text and pictures on the website.
     * Include Project V icon files.
     * Including the source code used to generate the website, namely [v2fly/v2fly-github-io](https://github.com/v2fly/v2fly-github-io).


### PR DESCRIPTION
`v2fly-github-io` has conflicting licensing requirements on the Readme (landing page) in both the Chinese and English version. The text specifies **CC BY-SA 4.0 International**, but links to **CC BY 4.0 International**, which drops the important copyleft aspect of the license:
```md
* 网站（[v2fly.org](https://www.v2fly.org/)）以 [CC BY SA 4.0 国际许可协议](https://creativecommons.org/licenses/by/4.0/deed.zh) 授权。`
```
```md
* The website ([v2fly.org](https://www.v2fly.org/)) is authorized under the [CC BY SA 4.0 International License Agreement](https://creativecommons.org/licenses/by/4.0/deed.zh) .
```
This pull assumes that the license specified on the repository itself constitutes precedent (`v2fly-github-io/LICENSE` file uses BY-SA 4.0 International), and corrects both links to BY-SA 4.0 International instead of BY 4.0 International.