### PR TITLE
Separate v4 and v5 docs on site navbar

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -57,7 +57,8 @@ export default defineUserConfig({
                 contributorsText: '贡献者',
                 navbar: [
                     { text: '快速开始', link: '/guide/start', },
-                    { text: '配置文档', link: '/v5/config/overview', },
+                    { text: 'v4 配置文档', link: '/config/overview', },
+                    { text: 'v5 配置文档', link: '/v5/config/overview', },
                     { text: '工具列表', link: '/awesome/tools' },
                     { text: '开发手册', link: '/developer/intro/compile', },
                     { text: '新白话文指南', link: 'https://guide.v2fly.org/' },
@@ -216,7 +217,8 @@ export default defineUserConfig({
                 lastUpdatedText: 'Last Updated',
                 navbar: [
                     { text: 'Quick Start', link: '/en_US/guide/start', },
-                    { text: 'Config Reference', link: '/en_US/v5/config/overview', },
+                    { text: 'v4 Config Reference', link: '/en_US/config/overview', },
+                    { text: 'v5 Config Reference', link: '/en_US/v5/config/overview', },
                     { text: 'Tools', link: '/en_US/awesome/tools' },
                     { text: 'Developer Guide', link: '/en_US/developer/intro/compile', },
                     { text: 'New concise guide', link: 'https://guide.v2fly.org/' },


### PR DESCRIPTION
Replacing the v4 config docs with v5 docs entirely for the navbar entry (1e443b2 etc.) is not currently viable, for a multitude of reasons:

- v5 Docs are still quite patchy, lacking many parameter descriptions, sample configs, and tips normally present in v4 docs.
- v5 Docs are missing some parameters, especially for protocols (proxies).
- Virtually all package manager repositories are still serving some minor version of v4. v5 is still in pre-release stage and isn't anywhere near stable enough for the average user or administrator to use for critical services.

This PR proposes separating v4 and v5 documentation as separate entries in the sidebar as the v5 stable release gradually rolls out. v4 docs should remain readily available until it becomes deprecated.

Package repository status, as of August 30th, 2022:

![68747470733a2f2f7265706f6c6f67792e6f72672f62616467652f766572746963616c2d616c6c7265706f732f76327261792e737667](https://user-images.githubusercontent.com/29967594/187530265-415e49ab-8645-4bf2-a3f6-fcff24d4444d.svg)
