### PR TITLE
v5: "routing" -> "router"

### DIFF
--- a/docs/en_US/v5/config/overview.md
+++ b/docs/en_US/v5/config/overview.md
@@ -16,7 +16,7 @@ To run your configure file in V5, execute `./v2ray run -c $configure_file_name -
 {
     "log": {},
     "dns": {},
-    "routing": {},
+    "router": {},
     "inbounds": [],
     "outbounds": [],
     "services": {}
@@ -35,7 +35,7 @@ Built-in DNS client. Specify hostname resolution settings.
 
 Local DNS will be used if this entry is not set.
 
-> `routing`: [RoutingObject](router.md)
+> `router`: [RoutingObject](router.md)
 
 Routing.
 

--- a/docs/en_US/v5/config/proxy/blackhole.md
+++ b/docs/en_US/v5/config/proxy/blackhole.md
@@ -1,6 +1,6 @@
 # Blackhole
 
-Blackhole (black hole) is an outbound data protocol, which will hinder the outbound of all data.  When used with [Routing](../routing.md), it can achieve the effect of prohibiting access to certain websites.
+Blackhole (black hole) is an outbound data protocol, which will hinder the outbound of all data.  When used with [Router](../router.md), it can achieve the effect of prohibiting access to certain websites.
 
 
 ## Blackhole Outbound

--- a/docs/v5/config/overview.md
+++ b/docs/v5/config/overview.md
@@ -16,7 +16,7 @@
 {
     "log": {},
     "dns": {},
-    "routing": {},
+    "router": {},
     "inbounds": [],
     "outbounds": [],
     "services": {}
@@ -35,7 +35,7 @@
 
 若未设置此项，则默认使用本机的 DNS 设置。
 
-> `routing`: [RoutingObject](router.md)
+> `router`: [RoutingObject](router.md)
 
 路由功能。
 


### PR DESCRIPTION
"router" should be the correct one, see https://github.com/v2fly/v2ray-core/blob/0cf7ac64da7c20020748c744ea586d95cdaad8de/infra/conf/v5cfg/skeleton.go#L16