### PR TITLE
Fix shadowsocks encryption method enums in v5 docs

### DIFF
--- a/docs/en_US/v5/config/proxy/shadowsocks.md
+++ b/docs/en_US/v5/config/proxy/shadowsocks.md
@@ -56,13 +56,13 @@ A password recognized by server.
 
 ## Supported Encryption Methods
 
-* `"aes-256-gcm"`
-* `"aes-128-gcm"`
-* `"chacha20-poly1305"` | `"chacha20-ietf-poly1305"`
-* `"none"` | `"plain"`
+* `"AES_256_GCM"`
+* `"AES_128_GCM"`
+* `"CHACHA20_POLY1305"`
+* `"NONE"`
 
 ::: warning
-In "none" unencrypted and unauthenticated mode, the server will not try to validate the password.
+In "NONE" unencrypted and unauthenticated mode, the server will not try to validate the password.
 
 This is typically used when authentication is already completed by the transport layer, like enabling TLS encryption and WebSocket transport with a long and unpredictable path.
 :::


### PR DESCRIPTION
According to the specified enums [in here](https://github.com/v2fly/v2ray-core/blob/master/proxy/shadowsocks/config.pb.go#L31). encryption method should be in `UPPER_SNAKE_CASE`.

using previous values in config will cause following error: 
```
Failed to start: main/commands: failed to load config: [config.v5.json] > infra/conf/v5cfg: unable to build config > infra/conf/v5cfg: unable to load inbound protocol config > common/registry: unable to parse json content > unknown value "\"aes-256-gcm\"" for enum v2ray.core.proxy.shadowsocks.CipherType
```