### PR TITLE
DNS over QUIC port update

### DIFF
--- a/docs/v5/config/dns.md
+++ b/docs/v5/config/dns.md
@@ -29,8 +29,8 @@ V2Ray 内建了一个 DNS 组件，其主要用途为：对目标地址（域名
   - 默认使用 `443` 端口进行查询，支持使用非标准端口和非标准路径，如 `https+local://a.b.c.d:8443/my-dns-query`
 - DNS over **QUIC local mode**：查询请求不经过路由组件，直接从 freedom outbound 发出
   - 使用 `quic+local://host` 的形式，如 `quic+local://dns.adguard.com`
-  - 默认使用 `784` 端口进行查询，支持使用非标准端口
-  - 目前（2021 年 9 月 20 日），公共递归 DNS 服务中支持 DNS over QUIC 协议的有 `dns.adguard.com` 与 `dns.nextdns.io`（除 784 端口外，亦支持使用 8853 端口查询）
+  - 默认使用 `853` 端口进行查询，支持使用非标准端口
+  - 目前（2022 年 11 月 20 日），公共递归 DNS 服务中支持 DNS over QUIC 协议的有 `dns.adguard.com` 与 `dns.nextdns.io`。
 - 特殊项：
   - **localhost**：使用本机预设的 DNS 配置
   - **FakeDNS**：使用 V2Ray 内建的 FakeDNS 服务器。详情见 [FakeDNS 服务器](fakedns.md)。


### PR DESCRIPTION
Since the release of v5.1.0, the default port for DNS over QUIC has been changed from 784 to 853