### PR TITLE
檔案與實際使用有區別

### DIFF
--- a/docs/v5/config/geo.md
+++ b/docs/v5/config/geo.md
@@ -42,15 +42,13 @@ GeoDomain 文件路径。
 
 ### DomainObject
 
-> `type` : "Plain" | "Regex" | "RootDomain" | "Full"
+> ["type","value"]
 
-域名匹配模式，可选值为：
+`type`：域名匹配模式，可选值为：
 
-* **Plain**：纯字符串匹配模式，当匹配目标域名中任意部分时，该规则生效。比如 `sina.com` 可以匹配 `sina.com`、`sina.com.cn`、`sina.company` 和 `www.sina.com`，但不匹配 `sina.cn`。
-* **Regex**：正则表达式匹配模式，当正则表达式匹配目标域名时，该规则生效。例如 `\.goo.*\.com$` 匹配 `www.google.com`、`fonts.googleapis.com`，但不匹配 `google.com`。
-* **RootDomain**：根域名匹配模式，当域名是目标域名或其子域名时，该规则生效。例如 `v2ray.com` 匹配 `www.v2ray.com`、`v2ray.com`，但不匹配 `xv2ray.com`。
-* **Full**：完整匹配模式，当域名完整匹配目标域名时，该规则生效。例如 `v2ray.com` 匹配 `v2ray.com` 但不匹配 `www.v2ray.com`。
+* `Plain`：纯字符串匹配模式，当匹配目标域名中任意部分时，该规则生效。比如 `sina.com` 可以匹配 `sina.com`、`sina.com.cn`、`sina.company` 和 `www.sina.com`，但不匹配 `sina.cn`。
+* `Regex`：正则表达式匹配模式，当正则表达式匹配目标域名时，该规则生效。例如 `\.goo.*\.com$` 匹配 `www.google.com`、`fonts.googleapis.com`，但不匹配 `google.com`。
+* `RootDomain`：根域名匹配模式，当域名是目标域名或其子域名时，该规则生效。例如 `v2ray.com` 匹配 `www.v2ray.com`、`v2ray.com`，但不匹配 `xv2ray.com`。
+* `Full`：完整匹配模式，当域名完整匹配目标域名时，该规则生效。例如 `v2ray.com` 匹配 `v2ray.com` 但不匹配 `www.v2ray.com`。
 
-> `value`: string
-
-匹配域名的值。
+`value`：匹配域名的值。


### PR DESCRIPTION
> V2Ray 5.2.1 (V2Fly, a community-driven edition of V2Ray.) Custom (go1.19.4 linux/arm64)

在以上的版本運行這個config可行：
```
  "routing":{
    "rules":[
      {
        "type": "field",
        "inboundTag": ["tunnel"],
        "domain":[
          "Plain","example.test"
        ],
        "outboundTag": "re"
      }
```
把domainObject換成這個也行：
```
"domain":[
"Full","example.test"
```
依照[這裡](https://guide.v2fly.org/app/reverse2.html#b-%E7%9A%84%E9%85%8D%E7%BD%AE)`full:example.test`的格式也行，但是換成其他的，例如`plain:example.test`就會報錯。

因此提交這個PR，希望能更正檔案，減少排除bug的時間。