### PR TITLE
fix GeoIP CIDR and Stream TLS Certificate display type

### DIFF
--- a/docs/v5/config/geo.md
+++ b/docs/v5/config/geo.md
@@ -2,7 +2,7 @@
 
 ## GeoIP
 
-> `cidr` : [CIDRObject](#CIDRObject)
+> `cidr` : \[[CIDRObject](#CIDRObject)\]
 
 一个数组，数组中每一项是一个 [CIDR](https://zh.wikipedia.org/zh-hans/%E6%97%A0%E7%B1%BB%E5%88%AB%E5%9F%9F%E9%97%B4%E8%B7%AF%E7%94%B1) 地址块
 

--- a/docs/v5/config/stream.md
+++ b/docs/v5/config/stream.md
@@ -55,7 +55,7 @@ security.tls
 
 在连接因为此策略失败时，会展示此证书链散列。不建议使用这种方式获得证书链散列值，因为在这种情况下您没有机会验证此时服务器提供的证书是否为真实证书。
 
-> `certificate`: [CertificateObject](#CertificateObject)
+> `certificate`: \[[CertificateObject](#CertificateObject)\]
 
 
 ### CertificateObject


### PR DESCRIPTION
CIDR and certificate should be an array rather than an object