### PR TITLE
fix incorrect RuleObject key `domains` to `domain`

### DIFF
--- a/docs/config/routing.md
+++ b/docs/config/routing.md
@@ -47,7 +47,7 @@ V2Ray 内建了一个路由模块，可以将入站数据按需求由不同的�
 {
     "domainMatcher": "mph",
     "type": "field",
-    "domains": [
+    "domain": [
         "baidu.com",
         "qq.com",
         "geosite:cn",
@@ -89,7 +89,7 @@ V2Ray 内建了一个路由模块，可以将入站数据按需求由不同的�
 ```
 
 :::tip
-当多个属性同时指定时，这些属性需要同时满足，才可以使当前规则生效。即 `domains` 和 `ip` 规则需要分开使用。
+当多个属性同时指定时，这些属性需要同时满足，才可以使当前规则生效。即 `domain` 和 `ip` 规则需要分开使用。
 :::
 
 > `domainMatcher`: "linear" | "mph"
@@ -104,7 +104,7 @@ V2Ray 内建了一个路由模块，可以将入站数据按需求由不同的�
 
 目前只支持 `field` 这一个选项。
 
-> `domains`: \[string\]
+> `domain`: \[string\]
 
 一个数组，数组每一项是一个域名的匹配。有以下几种形式：
 


### PR DESCRIPTION
According to v2ray-core source
[master branch](https://github.com/v2ray/v2ray-core/blob/master/infra/conf/router.go#L388)
```go
type RawFieldRule struct {
	RouterRule
	Domain     *StringList  `json:"domain"`
	IP         *StringList  `json:"ip"`
	Port       *PortList    `json:"port"`
	Network    *NetworkList `json:"network"`
	SourceIP   *StringList  `json:"source"`
	SourcePort *PortList    `json:"sourcePort"`
	User       *StringList  `json:"user"`
	InboundTag *StringList  `json:"inboundTag"`
	Protocols  *StringList  `json:"protocol"`
	Attributes string       `json:"attrs"`
}
```
[4.45.2 branch](https://github.com/v2fly/v2ray-core/blob/v4.45.2/infra/conf/rule/rule.go#L207)
```go
type RawFieldRule struct {
	RouterRule
	Domain     *cfgcommon.StringList  `json:"domain"`
	Domains    *cfgcommon.StringList  `json:"domains"`
	IP         *cfgcommon.StringList  `json:"ip"`
	Port       *cfgcommon.PortList    `json:"port"`
	Network    *cfgcommon.NetworkList `json:"network"`
	SourceIP   *cfgcommon.StringList  `json:"source"`
	SourcePort *cfgcommon.PortList    `json:"sourcePort"`
	User       *cfgcommon.StringList  `json:"user"`
	InboundTag *cfgcommon.StringList  `json:"inboundTag"`
	Protocols  *cfgcommon.StringList  `json:"protocol"`
	Attributes string                 `json:"attrs"`
}
```

In master branch, `RuleObject` in `RoutingObject` has only `domain` key while both `domains` and `domain` key existed in 4.45.2 version.

However, the example of `config.json` in 4.45.2 release took `domain` key instead of `domains` that confuse some users like me. I suggest the doc consisting with release example.

This PR is created to fix this.

Related issue: fix #445 