### PR TITLE
Document Multipath TCP support

### DIFF
--- a/docs/config/transport.md
+++ b/docs/config/transport.md
@@ -277,7 +277,8 @@ TLS 配置。TLS 由 Golang 提供，支持 TLS 1.3，不支持 DTLS。
     "tcpFastOpen": false,
     "tcpFastOpenQueueLength": 4096,
     "tproxy": "off",
-    "tcpKeepAliveInterval": 0
+    "tcpKeepAliveInterval": 0,
+    "mptcp": false
 }
 ```
 
@@ -321,3 +322,12 @@ TLS 配置。TLS 由 Golang 提供，支持 TLS 1.3，不支持 DTLS。
 TCP 保持活跃的数据包的发送间隔，以秒为单位（仅适用于 Linux）。 (v4.39.0+)
 
 0 代表保持默认值。
+
+> `mptcp`: true | false
+
+是否启用多路径TCP（仅适用于Linux）。
+
+* `true`: MPTCP 已打开。如果另一端的主机不支持 MPTCP，MPTCP 将恢复使用 TCP。
+* `false`: MPTCP 已关闭。
+
+当此项不存在时，将使用系统默认设置。可用于入站和出站连接。

--- a/docs/en_US/config/transport.md
+++ b/docs/en_US/config/transport.md
@@ -247,7 +247,8 @@ When `usage` is `"verify"`, both `keyFile` and `key` can be empty.
 {
     "mark": 0,
     "tcpFastOpen": false,
-    "tproxy": "off"
+    "tproxy": "off",
+    "mptcp": false
 }
 ```
 
@@ -281,3 +282,12 @@ Transparent proxy requires Root or CAP\_NET\_ADMIN authority.
 :::tip
 When `followRedirect` is specified in [Dokodemo-door](protocols/dokodemo.md) and `sockopt.tproxy` is empty, the value of `sockopt.tproxy` will be set to `"redirect"`.
 :::
+
+> `mptcp`: true | false
+
+Whether to enable Multipath TCP (only for Linux).
+
+* `true`: MPTCP is turned on. If the host on the other side doesn't support MPTCP, MPTCP will fall back to using TCP.
+* `false`: MPTCP is turned off.
+
+When this item does not exist, the system default setting is used. Can be used for inbound and outbound connections.


### PR DESCRIPTION
Hello. This patch documents the Multipath TCP support brought with v2ray-core v5.17.0. I don't know Chinese so I've translated the English text to Chinese. Feel free to address any issues.