### PR TITLE
.vuepress: config: add missing hysteria2 pages and sync page list

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -308,11 +308,11 @@ export default defineUserConfig({
                                 '/en_US/config/protocols/trojan',
                                 '/en_US/config/protocols/vless',
                                 '/en_US/config/protocols/loopback',
+                                '/en_US/config/protocols/hy2',
                             ],
                         },
                         {
                             text: 'Transport',
-                            
                             children: [
                                 '/en_US/config/transport/tcp',
                                 '/en_US/config/transport/mkcp',
@@ -321,6 +321,7 @@ export default defineUserConfig({
                                 '/en_US/config/transport/quic',
                                 '/en_US/config/transport/domainsocket',
                                 '/en_US/config/transport/grpc',
+                                '/en_US/config/transport/hy2',
                             ],
                         },
                         {
@@ -374,19 +375,20 @@ export default defineUserConfig({
                         {
                             text: 'Proxy Protocol',
                             children: [
+                                '/en_US/v5/config/proxy/blackhole',
+                                '/en_US/v5/config/proxy/dns',
+                                '/en_US/v5/config/proxy/dokodemo',
+                                '/en_US/v5/config/proxy/freedom',
+                                '/en_US/v5/config/proxy/http',
                                 '/en_US/v5/config/proxy/socks',
                                 '/en_US/v5/config/proxy/vmess',
                                 '/en_US/v5/config/proxy/vlite',
                                 '/en_US/v5/config/proxy/shadowsocks',
                                 '/en_US/v5/config/proxy/shadowsocks2022',
-                                '/en_US/v5/config/proxy/http',
-                                '/en_US/v5/config/proxy/dokodemo',
-                                '/en_US/v5/config/proxy/freedom',
-                                '/en_US/v5/config/proxy/loopback',
-                                '/en_US/v5/config/proxy/blackhole',
-                                '/en_US/v5/config/proxy/dns',
                                 '/en_US/v5/config/proxy/trojan',
+                                '/en_US/v5/config/proxy/hy2',
                                 '/en_US/v5/config/proxy/vless',
+                                '/en_US/v5/config/proxy/loopback',
                             ],
                         },
                         {
@@ -399,6 +401,7 @@ export default defineUserConfig({
                                 '/en_US/v5/config/stream/quic',
                                 '/en_US/v5/config/stream/meek',
                                 '/en_US/v5/config/stream/httpupgrade',
+                                '/en_US/v5/config/stream/hy2',
                             ],
                         },
                         {

--- a/docs/en_US/config/protocols/hy2.md
+++ b/docs/en_US/config/protocols/hy2.md
@@ -1,3 +1,3 @@
-# WebSocket
+# Hysteria2
 
 The documentation for this page is missing. Please submit a [pull request](https://github.com/v2fly/v2fly-github-io/pulls) or refer to the Chinese documentation.

--- a/docs/en_US/config/transport/hy2.md
+++ b/docs/en_US/config/transport/hy2.md
@@ -1,3 +1,3 @@
-# WebSocket
+# Hysteria2
 
 The documentation for this page is missing. Please submit a [pull request](https://github.com/v2fly/v2fly-github-io/pulls) or refer to the Chinese documentation.

--- a/docs/en_US/v5/config/proxy/hy2.md
+++ b/docs/en_US/v5/config/proxy/hy2.md
@@ -1,3 +1,3 @@
-# WebSocket
+# Hysteria2
 
 The documentation for this page is missing. Please submit a [pull request](https://github.com/v2fly/v2fly-github-io/pulls) or refer to the Chinese documentation.

--- a/docs/en_US/v5/config/stream.md
+++ b/docs/en_US/v5/config/stream.md
@@ -21,14 +21,17 @@ It has to be one of supported Security Protocol.
 
 > `socketSettings`: [SocketConfigObject](#socketconfigobject)
 
-### Supported Streams
+## Supported Streams
 
+* [TCP](stream/tcp.md)
 * [WebSocket](stream/websocket.md)
 * [mKCP](stream/kcp.md)
-* [tcp](stream/tcp.md)
+* [gRPC](stream/grpc.md)
 * [QUIC](stream/quic.md)
 * [meek](stream/meek.md)
 * [httpupgrade](stream/httpupgrade.md)
+* [Hysteria2](stream/hy2.md)
+
 
 ## TLS
 * Name: `tls`
@@ -59,7 +62,8 @@ This option allow TLS certificate verification to be turned off if the `pinnedPe
 
 > `certificate`: [[CertificateObject](#certificateobject)]
 
-# CertificateObject
+
+### CertificateObject
 
 > `usage` : string
 

--- a/docs/en_US/v5/config/stream/hy2.md
+++ b/docs/en_US/v5/config/stream/hy2.md
@@ -1,3 +1,3 @@
-# WebSocket
+# Hysteria2
 
 The documentation for this page is missing. Please submit a [pull request](https://github.com/v2fly/v2fly-github-io/pulls) or refer to the Chinese documentation.

--- a/docs/v5/config/stream.md
+++ b/docs/v5/config/stream.md
@@ -27,9 +27,9 @@
 
 ## 支持的传输流协议
 
-* [mKCP](stream/kcp.md)
 * [TCP](stream/tcp.md)
 * [WebSocket](stream/websocket.md)
+* [mKCP](stream/kcp.md)
 * [gRPC](stream/grpc.md)
 * [QUIC](stream/quic.md)
 * [meek](stream/meek.md)


### PR DESCRIPTION
Add the missing Hysteria2 pages to the English documentation. Synchronise the page list with the Chinese documentation. Add gRPC to en_US/v5/config/stream.md and make other small improvements.

@xiaokangwang, as you're maintaining the documentation, could you make sure in the future that the page lists for both languages are always in sync? With this patch, the page lists are in perfect sync.