### PR TITLE
fix(render/blockquote): fix blockquote text was rendered as black in dark mode

### DIFF
--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,9 +1,6 @@
 div.theme-default-content:not(.custom) {
     max-width: 100%;
 }
-html:not(.dark) blockquote {
-    color: #000;
-}
 blockquote {
     border-left: 4px solid #64b5f6;
     border-top: 1px solid #64b5f6;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d1e974a4-a5fe-47e5-bf23-8c74bfa92a5b)
After:
![image](https://github.com/user-attachments/assets/a8780919-8eb2-455f-8d9a-973cde7ba38f)