### PR TITLE
Add field description of fallbackObject in v5 config

### DIFF
--- a/docs/en_US/v5/config/protocol/user.md
+++ b/docs/en_US/v5/config/protocol/user.md
@@ -7,10 +7,8 @@
   "level": 0,
   "email": "",
   "account": {
-    {
-      "@type": "v2ray.core.proxy.trojan.Account",
-      "password": ""
-    }
+    "@type": "v2ray.core.proxy.trojan.Account",
+    "password": ""
   }
 }
 ```

--- a/docs/en_US/v5/config/proxy/trojan.md
+++ b/docs/en_US/v5/config/proxy/trojan.md
@@ -139,6 +139,10 @@ A password recognized by server.
 
 > `type`: string
 
+The network protocol to use. Common values include "tcp", "tcp4" (IPv4 only), "tcp6" (IPv6 only).
+
 > `dest`: string
+
+The destination address, typically in the form of "host:port", ex: "127.0.0.1:80" .
 
 > `xver`: uint64

--- a/docs/v5/config/proxy/trojan.md
+++ b/docs/v5/config/proxy/trojan.md
@@ -65,7 +65,9 @@ UDP 包编码方式，默认值为 `None`。(v5.4.0+)
 
 ```json
 {
-  "server": []
+  "users": [],
+  "packetEncoding": "None",
+  "fallbacks": []
 }
 ```
 

--- a/docs/v5/config/proxy/trojan.md
+++ b/docs/v5/config/proxy/trojan.md
@@ -124,6 +124,10 @@ UDP 包编码方式，默认值为 `None`。(v5.4.0+)
 
 > `type`: string
 
+网络协议. "tcp", "tcp4" (仅IPv4), "tcp6" (仅IPv6).
+
 > `dest`: string
+
+目标地址, 格式为 "host:port", ex: "127.0.0.1:80" .
 
 > `xver`: uint64


### PR DESCRIPTION
while using trojan fallback in v5, the type field and dest field is a little different than v4, add docs to clarify
