### PR TITLE
Suggest users to use ghcr.io/v2fly/v2ray:latest-extra

### DIFF
--- a/docs/en_US/guide/install.md
+++ b/docs/en_US/guide/install.md
@@ -75,7 +75,7 @@ What's new?
 
 The V2Ray Docker Image is also available:
 
-* [ghcr.io/v2fly/v2ray:latest-extra](https://github.com/v2fly/v2ray-core/pkgs/container/v2ray/625429681?tag=latest-extra): The `latest-extra` tag will be automatically updated with the latest release. Other versions will be released using the version's tag, e.g. `4.27.0`.
+* V2Ray provides a precompiled Docker image for the Linux platform: [ghcr.io/v2fly/v2ray:latest-extra](https://github.com/v2fly/v2ray-core/pkgs/container/v2ray/625429681?tag=latest-extra): The `latest-extra` tag will be automatically updated with the latest release. Other versions will be released using the version's tag, e.g. `4.27.0`.
 
 The Structure of Docker Image:
 

--- a/docs/en_US/guide/install.md
+++ b/docs/en_US/guide/install.md
@@ -75,12 +75,13 @@ What's new?
 
 The V2Ray Docker Image is also available:
 
-* [v2fly/v2fly-core](https://hub.docker.com/r/v2fly/v2fly-core): The `latest` tag will be updated following [v2fly](https://github.com/v2fly/docker-fly)'s latest release. Other versions will be released using the version's tag, e.g. `4.27.0`.
+* [ghcr.io/v2fly/v2ray:latest-extra](https://github.com/v2fly/v2ray-core/pkgs/container/v2ray/625429681?tag=latest-extra): The `latest-extra` tag will be automatically updated with the latest release. Other versions will be released using the version's tag, e.g. `4.27.0`.
 
 The Structure of Docker Image:
 
-* `/etc/v2ray/config.json`: Config File
-* `/usr/bin/v2ray/v2ray`: V2Ray Main Process
-* `/usr/bin/v2ray/v2ctl`: V2Ctl Commandline Tools
-* `/usr/bin/v2ray/geoip.dat`: GeoIP Data
-* `/usr/bin/v2ray/geosite.dat`: GeoSite Data
+* `/opt/v2ray/etc/config.json`: Config File
+* `/opt/v2ray/bin/v2ray`: V2Ray Main Process
+* `/opt/v2ray/share/geoip.dat`: GeoIP Data
+* `/opt/v2ray/share/geosite.dat`: GeoSite Data
+
+* [v2fly/v2fly-core](https://hub.docker.com/r/v2fly/v2fly-core): The docker hub image is manually built in [v2fly](https://github.com/v2fly/docker), so it is not recommended due to the possibility of lacking updates. 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -110,13 +110,14 @@ LogsDirectory=v2ray
 
 ## Docker 安装方式
 
-* V2Ray 为 Linux 平台提供了预编译的 Docker image：[v2fly/v2fly-core](https://hub.docker.com/r/v2fly/v2fly-core)
-* GitHub 仓库：[github.com/v2fly/docker](https://github.com/v2fly/docker)
+
+
+* V2Ray 为 Linux 平台提供了预编译的 Docker image：[ghcr.io/v2fly/v2ray:latest-extra](https://github.com/v2fly/v2ray-core/pkgs/container/v2ray)。其中的 "latest-extra" 标签会自动更新至最新发布版本。其他版本将使用版本号作为标签发布，例如 "4.27.0"。
 
 Docker image 的文件结构：
+* `/opt/v2ray/etc/config.json`: 配置文件
+* `/opt/v2ray/bin/v2ray`: V2Ray 主程序
+* `/opt/v2ray/share/geoip.dat`: GeoIP 数据文件
+* `/opt/v2ray/share/geosite.dat`: GeoSite 数据文件
 
-* `/etc/v2ray/config.json`：配置文件
-* `/usr/bin/v2ray`：V2Ray 主程序
-* `/usr/bin/v2ctl`：V2Ray 辅助工具
-* `/usr/local/share/v2ray/geoip.dat`：IP 数据文件
-* `/usr/local/share/v2ray/geosite.dat`：域名数据文件
+[v2fly/v2fly-core](https://hub.docker.com/r/v2fly/v2fly-core)：此 Docker Hub 镜像是在[v2fly/docker](https://github.com/v2fly/docker)中手动构建的，可能存在更新滞后的情况，因此不再推荐使用。


### PR DESCRIPTION
Updated both Chinese and English doc to suggest users to use the ghcr.io/v2fly/v2ray:latest-extra image instead of https://hub.docker.com/r/v2fly/v2fly-core

Fixes https://github.com/v2fly/docker/issues/90