### PR TITLE
feat: add ClashFX (macOS, mihomo-based, actively maintained)

### DIFF
--- a/docs/awesome/tools.md
+++ b/docs/awesome/tools.md
@@ -64,6 +64,13 @@
     description="【正在更新】 AnyPortal使用完整v2ray（及其fork）核心, 支持Tun2socks, 系统代理, 自动更新等。"
 />
 
+<Tool
+    url="https://github.com/Clash-FX/ClashFX"
+    name="ClashFX"
+    :platforms="['mac']"
+    description="【正在更新】基于 mihomo 内核的 macOS 代理客户端，支持 TUN 增强模式（系统级全局流量接管）、规则路由、VMess/VLESS/Trojan/Shadowsocks/Hysteria2 协议，原生支持 Apple Silicon（M1-M4）。"
+/>
+
 ## 路由规则
 
 > V2Ray Rules Dat

--- a/docs/awesome/tools.md
+++ b/docs/awesome/tools.md
@@ -65,6 +65,13 @@
 />
 
 <Tool
+    url="https://github.com/ClashX-Pro/ClashX"
+    name="ClashX"
+    :platforms="['mac']"
+    description="【正在更新】经典 macOS 规则代理客户端，原 yichengchen/clashX 的维护分支，已修复 macOS 15 Sequoia 兼容性问题，支持 VMess/Shadowsocks/Trojan/Socks5 协议及订阅管理。"
+/>
+
+<Tool
     url="https://github.com/Clash-FX/ClashFX"
     name="ClashFX"
     :platforms="['mac']"


### PR DESCRIPTION
## What

Add [ClashFX](https://github.com/Clash-FX/ClashFX) to the third-party GUI client list.

## About ClashFX

ClashFX is an actively maintained macOS proxy client powered by the [mihomo](https://github.com/MetaCubeX/mihomo) core.

- **Platform**: macOS 12+ (native Apple Silicon M1–M4 support)
- **Status**: Actively maintained (1,000+ commits, v1.0.9, 10 releases)
- **License**: AGPL-3.0
- **Features**:
  - TUN Enhanced Mode — system-wide traffic capture (all TCP/UDP, not just browsers)
  - Rule-based routing: Domain, IP-CIDR, GeoIP, Process-level
  - Protocol support: VMess, VLESS, Trojan, Shadowsocks, Hysteria2
  - Remote subscription import with auto-update
  - Built-in YAML config editor with syntax highlighting
  - Fake-IP DNS mode
- **Website**: https://clashfx.com
- **GitHub**: https://github.com/Clash-FX/ClashFX

Evolved from the original ClashX project, rebuilt with native SwiftUI and mihomo core.